### PR TITLE
remove panelcard overflow-hidden

### DIFF
--- a/src/components/PanelCard/index.tsx
+++ b/src/components/PanelCard/index.tsx
@@ -25,7 +25,7 @@ export const PanelCard: React.FC<PanelCardProps> = ({
 }) => {
   return (
     <div
-      className={classNames('bg-white overflow-hidden shadow rounded-lg', {
+      className={classNames('bg-white shadow rounded-lg', {
         'divide-y divide-gray-200': !!divider,
       })}
     >

--- a/src/components/UserInfoPill/index.tsx
+++ b/src/components/UserInfoPill/index.tsx
@@ -103,7 +103,7 @@ export const UserInfoPill: React.FC<UserInfoPillProps> = ({
                 leaveTo="transform opacity-0 scale-95"
               >
                 <Menu.Items
-                  className={`w-32 mt-2 right-0 absolute overflow-hidden origin-top-right rounded-md shadow-lg bg-white ring-1 ring-black ring-opacity-5 active:outline-none ${
+                  className={`z-10 w-32 mt-2 right-0 absolute overflow-hidden origin-top-right rounded-md shadow-lg bg-white ring-1 ring-black ring-opacity-5 active:outline-none ${
                     ringColor || 'active:ring-blue-400'
                   }`}
                 >


### PR DESCRIPTION
This is because dropdowns and stuff just get hidden behind the panelcard, making some really hard to access.