### PR TITLE
Better breadcrumbs

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "displayName": "BCTC Components",
-  "version": "3.7.0",
+  "version": "3.7.1",
   "license": "MIT",
   "main": "dist/index.js",
   "typings": "dist/index.d.ts",

--- a/src/components/Breadcrumbs/index.tsx
+++ b/src/components/Breadcrumbs/index.tsx
@@ -26,7 +26,11 @@ export const Breadcrumbs: React.FC<BreadcrumbsProps> = ({
   darkMode,
 }) => {
   return (
-    <nav className='flex' aria-label='Breadcrumb'>
+<nav className={`flex px-5 py-3 rounded-lg ${
+  darkMode
+    ? 'bg-gray-700 border border-gray-900'
+    : 'border border-gray-200 bg-gray-50'
+  }`}>
       <ol role='list' className='flex items-center space-x-4'>
         <li>
           <div>


### PR DESCRIPTION
added border to breadcrumbs component, has dark mode as well.

<img width="1035" alt="image" src="https://user-images.githubusercontent.com/85417631/229307657-4d2dd1ba-d030-4870-b32f-cd3e53e51b1d.png">
<img width="1035" alt="image" src="https://user-images.githubusercontent.com/85417631/229307663-228d3c13-f1e2-4e03-94b9-7ab3f7216f5a.png">
